### PR TITLE
chore: sync flake8 max length with black

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 119


### PR DESCRIPTION
now both flake8 and black uses max length of 119

related issue: #5 